### PR TITLE
_.contains is different for lo dash and underscore - lo dash supports a ...

### DIFF
--- a/client/helpers/handlebars.js
+++ b/client/helpers/handlebars.js
@@ -128,7 +128,7 @@ Handlebars.registerHelper('breakLines', function (text) {
     var url = url.trim();
     var protocol = '';
 
-    if (!_.contains(url, "http")) {
+    if (url.indexOf("http") === -1) {
       protocol = "http://";
     }
 


### PR DESCRIPTION
...string and underscore does not, so switched to indexOf
